### PR TITLE
feat: Network error handling and snackbar display

### DIFF
--- a/app/src/main/java/com/example/deliveryapp/data/api/RestaurantService.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/api/RestaurantService.kt
@@ -3,6 +3,7 @@ package com.example.deliveryapp.data.api
 import com.example.deliveryapp.data.model.restaurant.Restaurant
 import com.example.deliveryapp.data.model.menu.Menu
 import com.example.deliveryapp.data.model.restaurant.Review
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.POST
@@ -10,17 +11,17 @@ import retrofit2.http.Path
 
 interface RestaurantService {
     @GET("restaurants")
-    suspend fun getRestaurants(): List<Restaurant>
+    suspend fun getRestaurants(): Response<List<Restaurant>>
 
     @GET("restaurants/{restaurantId}")
-    suspend fun getRestaurant(@Path("restaurantId") restaurantId: Int): Restaurant
+    suspend fun getRestaurant(@Path("restaurantId") restaurantId: Int): Response<Restaurant>
 
     @GET("restaurants/{restaurantId}/menu")
-    suspend fun getMenu(@Path("restaurantId") restaurantId: Int): Menu
+    suspend fun getMenu(@Path("restaurantId") restaurantId: Int): Response<Menu>
 
     @GET("restaurants/{restaurantId}/reviews")
-    suspend fun getReviews(@Path("restaurantId") restaurantId: Int): List<Review>
+    suspend fun getReviews(@Path("restaurantId") restaurantId: Int): Response<List<Review>>
 
     @POST("restaurants/{restaurantId}/reviews")
-    suspend fun addReview(@Path("restaurantId") restaurantId: Int, @Body review: Review)
+    suspend fun addReview(@Path("restaurantId") restaurantId: Int, @Body review: Review): Response<Nothing>
 }

--- a/app/src/main/java/com/example/deliveryapp/data/repository/RemoteRestaurantsRepository.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/repository/RemoteRestaurantsRepository.kt
@@ -8,15 +8,70 @@ import retrofit2.Retrofit
 import retrofit2.converter.gson.GsonConverterFactory
 
 class RemoteRestaurantsRepository : RestaurantsRepository {
-    override suspend fun fetchRestaurants(): List<Restaurant> = service.getRestaurants()
+    override suspend fun fetchRestaurants(): Result<List<Restaurant>> {
+        return try {
+            val res = service.getRestaurants()
 
-    override suspend fun fetchRestaurant(id: Int): Restaurant = service.getRestaurant(id)
+            if(res.isSuccessful)
+                Result.success(res.body()!!)
+            else
+                Result.failure(Exception(res.message()))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 
-    override suspend fun fetchMenu(restaurantId: Int): Menu = service.getMenu(restaurantId)
+    override suspend fun fetchRestaurant(id: Int): Result<Restaurant> {
+        return try {
+            val res = service.getRestaurant(id)
 
-    override suspend fun fetchReviews(restaurantId: Int): List<Review> = service.getReviews(restaurantId)
+            if(res.isSuccessful)
+                Result.success(res.body()!!)
+            else
+                Result.failure(Exception(res.message()))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
 
-    override suspend fun addReview(review: Review) = service.addReview(review.restaurantId, review)
+    override suspend fun fetchMenu(restaurantId: Int): Result<Menu> {
+        return try {
+            val res = service.getMenu(restaurantId)
+
+            if(res.isSuccessful)
+                Result.success(res.body()!!)
+            else
+                Result.failure(Exception(res.message()))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun fetchReviews(restaurantId: Int): Result<List<Review>> {
+        return try {
+            val res = service.getReviews(restaurantId)
+
+            if(res.isSuccessful)
+                Result.success(res.body()!!)
+            else
+                Result.failure(Exception(res.message()))
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun addReview(review: Review): Result<Unit> {
+        try {
+            val res = service.addReview(review.restaurantId, review)
+
+            return if(!res.isSuccessful)
+                Result.failure(Exception(res.message()))
+            else
+                Result.success(Unit)
+        } catch (e: Exception) {
+            return Result.failure(e)
+        }
+    }
 
     companion object {
         private val retrofit: Retrofit = Retrofit.Builder()

--- a/app/src/main/java/com/example/deliveryapp/data/repository/RestaurantsRepository.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/repository/RestaurantsRepository.kt
@@ -5,10 +5,10 @@ import com.example.deliveryapp.data.model.restaurant.Restaurant
 import com.example.deliveryapp.data.model.restaurant.Review
 
 interface RestaurantsRepository {
-    suspend fun fetchRestaurants(): List<Restaurant>
-    suspend fun fetchRestaurant(id: Int): Restaurant
-    suspend fun fetchMenu(restaurantId: Int): Menu
+    suspend fun fetchRestaurants(): Result<List<Restaurant>>
+    suspend fun fetchRestaurant(id: Int): Result<Restaurant>
+    suspend fun fetchMenu(restaurantId: Int): Result<Menu>
 
-    suspend fun fetchReviews(restaurantId: Int): List<Review>
-    suspend fun addReview(review: Review)
+    suspend fun fetchReviews(restaurantId: Int): Result<List<Review>>
+    suspend fun addReview(review: Review): Result<Unit>
 }

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/home/HomeScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
@@ -22,6 +24,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -36,6 +39,7 @@ import com.example.deliveryapp.ui.components.restaurant.RestaurantItem
 import com.example.deliveryapp.ui.components.shared.AppNavigationBar
 import com.example.deliveryapp.ui.navigation.Screen
 import com.example.deliveryapp.ui.screens.restaurant.RestaurantPage
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -44,15 +48,29 @@ fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
     val navController = LocalNavController.current
 
     val restaurants by homeViewModel.restaurants.observeAsState()
+    val errorMessage by homeViewModel.errorMessage.observeAsState()
     val favorites by homeViewModel.favorites.observeAsState()
     var isSheetVisible by remember { mutableStateOf(false) }
+
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         homeViewModel.fetchRestaurants()
         homeViewModel.fetchFavorites()
     }
 
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(it, withDismissAction = true)
+                homeViewModel.clearErrors()
+            }
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(
                 title = {

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/home/HomeViewModel.kt
@@ -22,10 +22,20 @@ class HomeViewModel(application: Application) : AndroidViewModel(application) {
     private val favoritesRepository = FavoritesRepository(application)
     val restaurants: LiveData<List<Restaurant>> = _restaurants
     val favorites: LiveData<List<Favorite>> = _favorites
+    private val _errorMessage = MutableLiveData<String?>()
+    val errorMessage: LiveData<String?> = _errorMessage
+
+    fun clearErrors() {
+        _errorMessage.postValue(null)
+    }
 
     fun fetchRestaurants() {
         viewModelScope.launch {
-            _restaurants.postValue(restaurantsRepository.fetchRestaurants())
+            val res = restaurantsRepository.fetchRestaurants()
+            if(res.isSuccess)
+                _restaurants.postValue(res.getOrNull()!!)
+            else
+                _errorMessage.postValue("Failed to fetch restaurants: ${res.exceptionOrNull()?.message}")
         }
     }
 

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/restaurant/RestaurantScreen.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/restaurant/RestaurantScreen.kt
@@ -13,6 +13,8 @@ import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
@@ -21,6 +23,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -51,11 +54,23 @@ fun RestaurantScreen(
 
     val restaurant by restaurantViewModel.restaurant.observeAsState()
     val menu by restaurantViewModel.menu.observeAsState()
+    val errorMessage by restaurantViewModel.errorMessage.observeAsState()
     var isSheetVisible by remember { mutableStateOf(false) }
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
 
     LaunchedEffect(Unit) {
         restaurantViewModel.fetchRestaurant(restaurantId)
         restaurantViewModel.fetchMenu(restaurantId)
+    }
+
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(it, withDismissAction = true)
+                restaurantViewModel.clearErrors()
+            }
+        }
     }
 
     if (isSheetVisible) {
@@ -67,6 +82,7 @@ fun RestaurantScreen(
     }
 
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         topBar = {
             TopAppBar(title = { Text("Delivery App") }, navigationIcon = {
                 Icon(

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/restaurant/RestaurantViewModel.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/restaurant/RestaurantViewModel.kt
@@ -21,31 +21,51 @@ class RestaurantViewModel(application: Application) : AndroidViewModel(applicati
     private val _reviews = MutableLiveData<List<Review>>()
     private val restaurantsRepository = RemoteRestaurantsRepository()
     private val reviewsRestaurant = ReviewsRepository(application)
+    private val _errorMessage = MutableLiveData<String?>()
     val restaurant: LiveData<Restaurant> = _restaurant
     val menu: LiveData<Menu> = _menu
     val reviews: LiveData<List<Review>> = _reviews
+    val errorMessage: LiveData<String?> = _errorMessage
+
+    fun clearErrors() {
+        _errorMessage.postValue(null)
+    }
 
     fun fetchRestaurant(restaurantId: Int) {
         viewModelScope.launch {
-            _restaurant.postValue(restaurantsRepository.fetchRestaurant(restaurantId))
+            val res = restaurantsRepository.fetchRestaurant(restaurantId)
+            if(res.isSuccess)
+                _restaurant.postValue(res.getOrNull()!!)
+            else
+                _errorMessage.postValue("Failed to fetch restaurant: ${res.exceptionOrNull()?.message}")
         }
     }
 
     fun fetchMenu(restaurantId: Int) {
         viewModelScope.launch {
-            _menu.postValue(restaurantsRepository.fetchMenu(restaurantId))
+            val res = restaurantsRepository.fetchMenu(restaurantId)
+            if(res.isSuccess)
+                _menu.postValue(res.getOrNull()!!)
+            else
+                _errorMessage.postValue("Failed to fetch menu: ${res.exceptionOrNull()?.message}")
         }
     }
 
     fun getRestaurantReviews(restaurantId: Int) {
         viewModelScope.launch {
-            _reviews.postValue(restaurantsRepository.fetchReviews(restaurantId))
+            val res = restaurantsRepository.fetchReviews(restaurantId)
+            if(res.isSuccess)
+                _reviews.postValue(res.getOrNull()!!)
+            else
+                _errorMessage.postValue("Failed to fetch reviews: ${res.exceptionOrNull()?.message}")
         }
     }
 
     suspend fun addReview(review: Review) {
         viewModelScope.launch {
-            restaurantsRepository.addReview(review)
+            val res = restaurantsRepository.addReview(review)
+            if(!res.isSuccess)
+                _errorMessage.postValue("Failed to fetch restaurant: ${res.exceptionOrNull()?.message}")
         }
     }
 }


### PR DESCRIPTION
## Description

This PR introduces network error handling. We wrap network calls with if-checks and try-catch statements and check for `retrofit`'s `Response` object status as seen in #5.

Also, we push error messages to the view model. These will be displayed through a snackbar in the respective screen.