### PR TITLE
fix: Error handling in RemoteFirstOrderRepository.kt

### DIFF
--- a/app/src/main/java/com/example/deliveryapp/HomeActivity.kt
+++ b/app/src/main/java/com/example/deliveryapp/HomeActivity.kt
@@ -12,7 +12,7 @@ import com.example.deliveryapp.ui.viewModel.OrderViewModel
 import com.example.deliveryapp.ui.viewModel.UserViewModel
 
 class HomeActivity : AppCompatActivity() {
-    private lateinit var orderViewModel: OrderViewModel
+    lateinit var orderViewModel: OrderViewModel
     lateinit var userViewModel: UserViewModel
     lateinit var cartViewModel: CartViewModel
 

--- a/app/src/main/java/com/example/deliveryapp/data/repository/OrderRepository.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/repository/OrderRepository.kt
@@ -5,7 +5,7 @@ import com.example.deliveryapp.data.model.OrderDetail
 import com.example.deliveryapp.data.model.OrderRequest
 
 interface OrderRepository {
-    suspend fun fetchOrders(token: String): List<Order>
-    suspend fun fetchOrderDetails(token: String, orderId: Int): List<OrderDetail>
-    suspend fun addOrder(token: String, order: OrderRequest)
+    suspend fun fetchOrders(token: String): Result<List<Order>>
+    suspend fun fetchOrderDetails(token: String, orderId: Int): Result<List<OrderDetail>>
+    suspend fun addOrder(token: String, order: OrderRequest): Result<Unit>
 }

--- a/app/src/main/java/com/example/deliveryapp/data/service/OrderService.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/service/OrderService.kt
@@ -3,6 +3,7 @@ package com.example.deliveryapp.data.service
 import com.example.deliveryapp.data.model.Order
 import com.example.deliveryapp.data.model.OrderDetail
 import com.example.deliveryapp.data.model.OrderRequest
+import retrofit2.Response
 import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.Header
@@ -12,11 +13,11 @@ import retrofit2.http.Path
 interface OrderService {
 
     @GET("orders")
-    suspend fun getOrders(@Header("Authorization") token: String): List<Order>
+    suspend fun getOrders(@Header("Authorization") token: String): Response<List<Order>>
 
     @GET("orders/{orderId}/details")
-    suspend fun getOrderDetails(@Header("Authorization") token: String, @Path("orderId") orderId: Int): List<OrderDetail>
+    suspend fun getOrderDetails(@Header("Authorization") token: String, @Path("orderId") orderId: Int): Response<List<OrderDetail>>
 
     @POST("orders")
-    suspend fun addOrder(@Header("Authorization") token: String, @Body order: OrderRequest)
+    suspend fun addOrder(@Header("Authorization") token: String, @Body order: OrderRequest) : Response<Unit>
 }

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/orders/OrdersScreen.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/orders/OrdersScreen.kt
@@ -3,24 +3,50 @@ package com.example.deliveryapp.ui.screens.orders
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.fragment.app.FragmentContainerView
 import androidx.fragment.app.FragmentManager
+import com.example.deliveryapp.HomeActivity
 import com.example.deliveryapp.R
 import com.example.deliveryapp.ui.components.shared.AppNavigationBar
 import com.example.deliveryapp.ui.fragments.order.OrderListFragment
+import kotlinx.coroutines.launch
 
 @Composable
 fun OrdersScreen(
     fragmentManager: FragmentManager
 ) {
+    val orderViewModel = (LocalContext.current as HomeActivity).orderViewModel
+    val errorMessage by orderViewModel.errorMessage.observeAsState()
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(it, withDismissAction = true)
+                orderViewModel.clearError()
+            }
+        }
+    }
+
     Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
         content = { paddingValues ->
             AndroidView(
-                modifier = Modifier.padding(paddingValues).fillMaxSize(),
+                modifier = Modifier
+                    .padding(paddingValues)
+                    .fillMaxSize(),
                 factory = {
                     context ->
                     val frgId = FragmentContainerView(context).apply {


### PR DESCRIPTION
## Description

Added `callOrderService` to gracefully handle errors in network requests. We show a snackbar in case of any errors.
We kept the remote first and fallback to the local cache present in RoomDB in the `onFailure` and `update` functions.