### PR TITLE
feat: Create and pick an address for an order

### DIFF
--- a/api/Models/Address.cs
+++ b/api/Models/Address.cs
@@ -9,7 +9,14 @@ public class Address
     [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
     public int Id { get; set; } = 0;
 
+    [ForeignKey("UserId")]
+    public required int UserId { get; set; } = 0;
+
     public required double Latitude { get; set; }
 
     public required double Longitude { get; set; }
+
+    public string? Street { get; set; }
+    public string? Building { get; set; }
+    public string? Apartment { get; set; }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -91,6 +91,9 @@ dependencies {
     implementation(libs.androidx.room.runtime)
     ksp(libs.androidx.room.compiler)
 
+    //location
+    implementation(libs.play.services.location)
+
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -4,6 +4,8 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 
     <application
         android:allowBackup="true"

--- a/app/src/main/java/com/example/deliveryapp/DeliveryApp.kt
+++ b/app/src/main/java/com/example/deliveryapp/DeliveryApp.kt
@@ -12,6 +12,8 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.toRoute
 import com.example.deliveryapp.ui.navigation.Screen
+import com.example.deliveryapp.ui.screens.address.CreateAddressPage
+import com.example.deliveryapp.ui.screens.address.CreateAddressScreen
 import com.example.deliveryapp.ui.screens.account.AccountScreen
 import com.example.deliveryapp.ui.screens.cart.CartPage
 import com.example.deliveryapp.ui.screens.cart.CartScreen
@@ -51,6 +53,7 @@ fun DeliveryApp(fragmentManager: FragmentManager) {
                 composable(Screen.Orders.route) { OrdersScreen(fragmentManager = fragmentManager) }
                 composable(Screen.Account.route) { AccountScreen() }
                 composable<CartPage> { CartScreen() }
+                composable<CreateAddressPage> { CreateAddressScreen() }
             }
         }
     }

--- a/app/src/main/java/com/example/deliveryapp/HomeActivity.kt
+++ b/app/src/main/java/com/example/deliveryapp/HomeActivity.kt
@@ -8,6 +8,7 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
 import com.example.deliveryapp.ui.screens.cart.CartViewModel
+import com.example.deliveryapp.ui.viewModel.AddressViewModel
 import com.example.deliveryapp.ui.viewModel.OrderViewModel
 import com.example.deliveryapp.ui.viewModel.UserViewModel
 
@@ -15,6 +16,7 @@ class HomeActivity : AppCompatActivity() {
     lateinit var orderViewModel: OrderViewModel
     lateinit var userViewModel: UserViewModel
     lateinit var cartViewModel: CartViewModel
+    lateinit var addressViewModel: AddressViewModel
 
     @RequiresApi(Build.VERSION_CODES.O)
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -25,6 +27,7 @@ class HomeActivity : AppCompatActivity() {
 
         userViewModel = ViewModelProvider(this)[UserViewModel::class.java]
         cartViewModel = ViewModelProvider(this)[CartViewModel::class.java]
+        addressViewModel = ViewModelProvider(this)[AddressViewModel::class.java]
 
         setContent { DeliveryApp(supportFragmentManager) }
     }

--- a/app/src/main/java/com/example/deliveryapp/data/model/Address.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/model/Address.kt
@@ -1,3 +1,11 @@
 package com.example.deliveryapp.data.model
 
-data class Address(val id: Int, val latitude: Double, val longitude: Double)
+data class Address(
+    val id: Int,
+    val userId: Int,
+    val latitude: Double,
+    val longitude: Double,
+    val street: String? = null,
+    val apartment: String? = null,
+    val building: String? = null
+)

--- a/app/src/main/java/com/example/deliveryapp/data/model/Order.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/model/Order.kt
@@ -23,6 +23,6 @@ data class Order(
     @ColumnInfo(name = "driver_rating_id") var driverRating: Int,
 ){
     constructor() : this(
-        0, -1, "", null, 0, "", "", Address(1, 0.0, 0.0), 0.0, 0.0, 0.0, "", 0, 0
+        0, -1, "", null, 0, "", "", Address(1,  1,0.0, 0.0), 0.0, 0.0, 0.0, "", 0, 0
     )
 }

--- a/app/src/main/java/com/example/deliveryapp/data/repository/RemoteUserRepository.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/repository/RemoteUserRepository.kt
@@ -1,6 +1,7 @@
 package com.example.deliveryapp.data.repository
 
 import android.content.Context
+import com.example.deliveryapp.data.model.Address
 import com.example.deliveryapp.data.model.JsonPatch
 import com.example.deliveryapp.data.model.TokenResponse
 import com.example.deliveryapp.data.model.User
@@ -38,6 +39,14 @@ class RemoteUserRepository(context: Context) : UserRepository {
 
     override suspend fun update(user: List<JsonPatch>): Result<User> {
         return callUserService { service.update(user) }
+    }
+
+    override suspend fun getAddresses(): Result<List<Address>> {
+        return callUserService { service.getAddresses() }
+    }
+
+    override suspend fun addAddress(address: Address): Result<Unit> {
+        return callUserService { service.addAddress(address) }
     }
 
     companion object {

--- a/app/src/main/java/com/example/deliveryapp/data/repository/UserRepository.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/repository/UserRepository.kt
@@ -1,5 +1,6 @@
 package com.example.deliveryapp.data.repository
 
+import com.example.deliveryapp.data.model.Address
 import com.example.deliveryapp.data.model.JsonPatch
 import com.example.deliveryapp.data.model.TokenResponse
 import com.example.deliveryapp.data.model.User
@@ -9,4 +10,6 @@ interface UserRepository {
     suspend fun login(user: User): Result<TokenResponse>
     suspend fun signup(user: User): Result<TokenResponse>
     suspend fun update(patch: List<JsonPatch>): Result<User>
+    suspend fun getAddresses(): Result<List<Address>>
+    suspend fun addAddress(address: Address): Result<Unit>
 }

--- a/app/src/main/java/com/example/deliveryapp/data/service/UserService.kt
+++ b/app/src/main/java/com/example/deliveryapp/data/service/UserService.kt
@@ -1,5 +1,6 @@
 package com.example.deliveryapp.data.service
 
+import com.example.deliveryapp.data.model.Address
 import com.example.deliveryapp.data.model.JsonPatch
 import com.example.deliveryapp.data.model.TokenResponse
 import com.example.deliveryapp.data.model.User
@@ -22,4 +23,10 @@ interface UserService {
 
     @PATCH("users")
     suspend fun update(@Body user: List<JsonPatch>): Response<User>
+
+    @GET("users/addresses")
+    suspend fun getAddresses(): Response<List<Address>>
+
+    @POST("users/addresses")
+    suspend fun addAddress(@Body address: Address): Response<Unit>
 }

--- a/app/src/main/java/com/example/deliveryapp/ui/components/location/LocationPickerBottomSheet.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/components/location/LocationPickerBottomSheet.kt
@@ -1,23 +1,47 @@
 package com.example.deliveryapp.ui.components.location
 
+import androidx.compose.foundation.gestures.Orientation
+import androidx.compose.foundation.gestures.scrollable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Home
 import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
+import com.example.deliveryapp.HomeActivity
+import com.example.deliveryapp.data.model.Address
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun LocationPickerBottomSheet(onDismissRequest: () -> Unit) {
+fun LocationPickerBottomSheet(
+    addresses: List<Address>,
+    onSelect: (address: Address) -> Unit,
+    onClick: () -> Unit,
+    onDismissRequest: () -> Unit
+) {
+    val addressViewModel = (LocalContext.current as HomeActivity).addressViewModel
+    val selectedAddress by addressViewModel.selectedAddress.observeAsState()
+
     ModalBottomSheet(onDismissRequest = onDismissRequest) {
         Column(
             verticalArrangement = Arrangement.spacedBy(16.dp),
@@ -28,10 +52,58 @@ fun LocationPickerBottomSheet(onDismissRequest: () -> Unit) {
             Text(
                 "Where should we deliver to?", fontWeight = FontWeight.Bold, fontSize = 20.sp
             )
-            Text("Deliver to my current location")
-            Text("Deliver somewhere else...")
 
-            Button(onClick = {}, modifier = Modifier.align(Alignment.CenterHorizontally)) {
+            Column(
+                verticalArrangement = Arrangement.spacedBy(8.dp),
+                modifier = Modifier.fillMaxWidth().scrollable(orientation = Orientation.Vertical, state = rememberScrollState())
+            ) {
+                addresses.forEach { addr ->
+                    Surface(
+                        { onSelect(addr) }, modifier = Modifier
+                            .fillMaxWidth()
+                            .clip(
+                                RoundedCornerShape(8.dp)
+                            )
+                    ) {
+                        Row(
+                            Modifier.padding(8.dp),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.spacedBy(8.dp)
+                        ) {
+                            val isTinted =
+                                selectedAddress != null && addr.id == selectedAddress!!.id
+                            val selectedColor =
+                                if (isTinted) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onBackground
+                            Icon(
+                                Icons.Filled.Home,
+                                "Home",
+                                tint = selectedColor,
+                                modifier = Modifier.weight(.1f)
+                            )
+                            Column(
+                                verticalArrangement = Arrangement.spacedBy(8.dp),
+                                modifier = Modifier.weight(.9f)
+                            ) {
+                                Text(
+                                    "Lat: ${addr.latitude} Long: ${addr.longitude}",
+                                    fontWeight = FontWeight.Bold,
+                                    color = selectedColor
+                                )
+                                Text(
+                                    if (addr.street == "" || addr.street == null) "Street not available" else addr.street
+                                )
+                                Text(
+                                    if (addr.building == "" || addr.building == null || addr.apartment == "" || addr.apartment == null)
+                                        "Apartment not available"
+                                    else "${addr.building}, ${addr.apartment}"
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+
+            Button(onClick = onClick, modifier = Modifier.align(Alignment.CenterHorizontally)) {
                 Text("Add New Address")
             }
         }

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/address/CreateAddressScreen.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/address/CreateAddressScreen.kt
@@ -1,0 +1,176 @@
+package com.example.deliveryapp.ui.screens.address
+
+import android.Manifest
+import android.content.pm.PackageManager
+import android.location.Location
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.livedata.observeAsState
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.content.ContextCompat
+import com.example.deliveryapp.HomeActivity
+import com.example.deliveryapp.LocalNavController
+import com.example.deliveryapp.data.model.Address
+import com.example.deliveryapp.ui.components.shared.AppNavigationBar
+import com.google.android.gms.location.LocationServices
+import kotlinx.coroutines.launch
+import kotlinx.serialization.Serializable
+
+@Serializable
+data object CreateAddressPage
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun CreateAddressScreen() {
+    val navController = LocalNavController.current
+    val context = LocalContext.current
+    val fusedLocationClient = LocationServices.getFusedLocationProviderClient(context)
+
+    val addressViewModel = (context as HomeActivity).addressViewModel
+
+    val error by addressViewModel.error.observeAsState()
+    val coroutineScope = rememberCoroutineScope()
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    var street by remember { mutableStateOf("") }
+    var apartment by remember { mutableStateOf("") }
+    var building by remember { mutableStateOf("") }
+    var location by remember { mutableStateOf<Location?>(null) }
+    val hasLocationPermission = remember {
+        ContextCompat.checkSelfPermission(
+            context, Manifest.permission.ACCESS_FINE_LOCATION
+        ) == PackageManager.PERMISSION_GRANTED
+    }
+    val permissionState = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.RequestPermission(),
+    ) { isGranted ->
+//            if (isGranted) {
+//                Toast.makeText(context, "Location Permission Granted", Toast.LENGTH_SHORT).show()
+//            } else {
+//                Toast.makeText(context, "Location Permission Denied", Toast.LENGTH_SHORT).show()
+//            }
+    }
+
+    LaunchedEffect(Unit) {
+        if (hasLocationPermission) {
+            fusedLocationClient.lastLocation.addOnSuccessListener { loc ->
+                location = loc
+            }
+        } else {
+            permissionState.launch(Manifest.permission.ACCESS_FINE_LOCATION)
+        }
+    }
+
+    LaunchedEffect(error) {
+        error?.let {
+            coroutineScope.launch {
+                snackbarHostState.showSnackbar(it, withDismissAction = true)
+                addressViewModel.clearError()
+            }
+        }
+    }
+
+    Scaffold(
+        snackbarHost = { SnackbarHost(snackbarHostState) },
+        topBar = {
+            TopAppBar(
+                title = { Text("Create New Address", fontWeight = FontWeight.Bold) },
+                navigationIcon = {
+                    Icon(
+                        Icons.AutoMirrored.Filled.ArrowBack,
+                        "Back",
+                        modifier = Modifier.clickable { navController.popBackStack() })
+                })
+        },
+        bottomBar = { AppNavigationBar() },
+    ) { padding ->
+        Column(
+            Modifier
+                .padding(padding)
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp),
+            verticalArrangement = Arrangement.spacedBy(16.dp)
+        ) {
+            Row (modifier = Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(16.dp)) {
+                TextField(
+                    value = if(location?.latitude == null) "" else location!!.latitude.toString(),
+                    onValueChange = { street = it },
+                    label = { Text("Latitude") },
+                    readOnly = true,
+                    modifier = Modifier.weight(1f)
+                )
+                TextField(
+                    value = if(location?.longitude == null) "" else location!!.longitude.toString(),
+                    onValueChange = { street = it },
+                    label = { Text("Longitude") },
+                    readOnly = true,
+                    modifier = Modifier.weight(1f)
+                )
+            }
+
+            TextField(
+                value = street,
+                onValueChange = { street = it },
+                label = { Text("Street") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            TextField(
+                value = building,
+                onValueChange = { building = it },
+                label = { Text("Building") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            TextField(
+                value = apartment,
+                onValueChange = { apartment = it },
+                label = { Text("Apartment") },
+                modifier = Modifier.fillMaxWidth()
+            )
+
+            Button({
+                if(location != null) {
+                    val address = Address(
+                        0,
+                        0,
+                        location!!.latitude,
+                        location!!.longitude,
+                        street,
+                        apartment,
+                        building
+                    )
+                    addressViewModel.addAddress(address)
+                }
+            }, Modifier.fillMaxWidth()) {
+                Text("Create Address")
+            }
+        }
+    }
+}
+

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/cart/CartScreen.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/cart/CartScreen.kt
@@ -54,7 +54,9 @@ data object CartPage
 fun CartScreen(orderViewModel: OrderViewModel = viewModel()) {
     val navController = LocalNavController.current
     val cartViewModel = (LocalContext.current as HomeActivity).cartViewModel
+    val addressViewModel = (LocalContext.current as HomeActivity).addressViewModel
     val cart by cartViewModel.cart.observeAsState()
+    val selectedAddress by addressViewModel.selectedAddress.observeAsState()
     val coroutineScope = rememberCoroutineScope()
     var isShown by remember { mutableStateOf(false) }
     val selectedRestaurantId by cartViewModel.selectedRestaurantId.observeAsState()
@@ -85,7 +87,7 @@ fun CartScreen(orderViewModel: OrderViewModel = viewModel()) {
                                 Column {
                                     Text(item.meal.name, fontSize = 18.sp)
                                     Text(
-                                        "USD ${item.price}",
+                                        "USD ${item.price * item.quantity}",
                                         fontSize = 14.sp,
                                         fontWeight = FontWeight.Bold
                                     )
@@ -99,9 +101,9 @@ fun CartScreen(orderViewModel: OrderViewModel = viewModel()) {
 
             Button(
                 {
-                    if (cart != null && selectedRestaurantId != null) {
+                    if (cart != null && selectedRestaurantId != null && selectedAddress != null) {
                         val order = OrderRequest(
-                            selectedRestaurantId!!, cart!!, 1, "Cash"
+                            selectedRestaurantId!!, cart!!, selectedAddress!!.id, "Cash"
                         )
                         orderViewModel.addOrder(order)
                         coroutineScope.launch {

--- a/app/src/main/java/com/example/deliveryapp/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/screens/home/HomeScreen.kt
@@ -41,6 +41,7 @@ import com.example.deliveryapp.data.model.restaurant.Restaurant
 import com.example.deliveryapp.ui.components.location.LocationPickerBottomSheet
 import com.example.deliveryapp.ui.components.restaurant.RestaurantItem
 import com.example.deliveryapp.ui.components.shared.AppNavigationBar
+import com.example.deliveryapp.ui.screens.address.CreateAddressPage
 import com.example.deliveryapp.ui.screens.cart.CartPage
 import com.example.deliveryapp.ui.screens.restaurant.RestaurantPage
 import kotlinx.coroutines.launch
@@ -49,6 +50,10 @@ import kotlinx.coroutines.launch
 @Composable
 fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
     val navController = LocalNavController.current
+    val context = LocalContext.current
+
+    val addressViewModel = (context as HomeActivity).addressViewModel
+    val addresses by addressViewModel.addresses.observeAsState()
 
     val restaurants by homeViewModel.restaurants.observeAsState()
     val errorMessage by homeViewModel.errorMessage.observeAsState()
@@ -61,6 +66,7 @@ fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
     LaunchedEffect(Unit) {
         homeViewModel.fetchRestaurants()
         homeViewModel.fetchFavorites()
+        addressViewModel.getAddresses()
     }
 
     LaunchedEffect(errorMessage) {
@@ -102,7 +108,14 @@ fun HomeScreen(homeViewModel: HomeViewModel = viewModel()) {
         },
         bottomBar = { AppNavigationBar() },
     ) { padding ->
-        if (isSheetVisible) LocationPickerBottomSheet { isSheetVisible = false }
+        if (isSheetVisible) LocationPickerBottomSheet(
+            addresses ?: emptyList(),
+            onSelect = { addr -> addressViewModel.selectAddress(addr) },
+            onClick = {
+                navController.navigate(CreateAddressPage)
+            }) {
+            isSheetVisible = false
+        }
 
         if (restaurants == null) Text("Loading...")
         else LazyColumn(

--- a/app/src/main/java/com/example/deliveryapp/ui/viewModel/AddressViewModel.kt
+++ b/app/src/main/java/com/example/deliveryapp/ui/viewModel/AddressViewModel.kt
@@ -1,0 +1,50 @@
+package com.example.deliveryapp.ui.viewModel
+
+import android.app.Application
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.viewModelScope
+import com.example.deliveryapp.data.model.Address
+import com.example.deliveryapp.data.repository.RemoteUserRepository
+import kotlinx.coroutines.launch
+
+class AddressViewModel(application: Application) : AndroidViewModel(application) {
+    private val userRepository = RemoteUserRepository(application)
+
+    private val _addresses: MutableLiveData<List<Address>> = MutableLiveData()
+    private val _error: MutableLiveData<String?> = MutableLiveData()
+    private val _selectedAddress: MutableLiveData<Address?> = MutableLiveData()
+
+    val addresses: LiveData<List<Address>> = _addresses
+    val selectedAddress: LiveData<Address?> = _selectedAddress
+    val error: LiveData<String?> = _error
+
+    fun getAddresses() {
+        viewModelScope.launch {
+            val result = userRepository.getAddresses()
+            if(result.isSuccess) {
+                _addresses.value = result.getOrNull()!!
+            } else {
+                _error.value = result.getOrElse { e -> e.message }.toString()
+            }
+        }
+    }
+
+    fun addAddress(address: Address) {
+        viewModelScope.launch {
+            val result = userRepository.addAddress(address)
+            if(result.isFailure) {
+                _error.value = result.getOrElse { e -> e.message }.toString()
+            }
+        }
+    }
+
+    fun selectAddress(address: Address) {
+        _selectedAddress.value = address
+    }
+
+    fun clearError() {
+        _error.value = null
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ material = "1.12.0"
 activity = "1.9.3"
 constraintlayout = "2.2.0"
 osmdroidAndroid = "6.1.14"
+playServicesLocation = "21.3.0"
 roomCompilerVersion = "2.6.0"
 roomRuntimeVersion = "2.6.1"
 kotlinxSerializationJson = "1.7.3"
@@ -59,6 +60,7 @@ kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serializa
 material = { group = "com.google.android.material", name = "material", version.ref = "material" }
 androidx-activity = { group = "androidx.activity", name = "activity", version.ref = "activity" }
 androidx-constraintlayout = { group = "androidx.constraintlayout", name = "constraintlayout", version.ref = "constraintlayout" }
+play-services-location = { module = "com.google.android.gms:play-services-location", version.ref = "playServicesLocation" }
 retrofit = { module = "com.squareup.retrofit2:retrofit", version.ref = "retrofit" }
 
 [plugins]


### PR DESCRIPTION
## Description

Users are now able to create addresses and pick between them to order. The selected address is the one used for the order.
The user can specify attributes such as street, bldg., and apartment paired with their GPS location which is mandatory.
The app prompts the user for getting their location.

## Changes
- Required endpoints on the API
- Modified the Address model
- Added a screen to create an address
- The address bottom sheet now allows the user to choose between existing locations